### PR TITLE
Выключение таски publishMainArtifactPublicationToMavenRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-### NEXT_VERSION_TYPE=MAJOR|MINOR|PATCH
+### NEXT_VERSION_TYPE=PATCH
 ### NEXT_VERSION_DESCRIPTION_BEGIN
+* Выключение таски publishMainArtifactPublicationToMavenRepository, т.к. публикация осуществляется с помощью таски 
+  gradle-nexus-staging-plugin.
 ### NEXT_VERSION_DESCRIPTION_END
 ## [7.3.1](https://github.com/yoomoney-gradle-plugins/gradle-project-plugin/pull/5) (20-04-2021)
 

--- a/configurator.gradle
+++ b/configurator.gradle
@@ -139,3 +139,9 @@ pluginBundle {
 }
 
 project.getExtensions().getByType(GradlePluginDevelopmentExtension.class).setAutomatedPublishing(false)
+//отключаем таску публикации, предоставляемую java-artifact-publish-plugin, т.к. io.github.gradle-nexus:publish-plugin
+//предоставляет свою
+afterEvaluate {
+    project.getTasks().getByName("publishMainArtifactPublicationToMavenRepository").setEnabled(false);
+}
+

--- a/src/main/java/ru/yoomoney/gradle/plugins/gradleproject/ExtensionConfigurator.java
+++ b/src/main/java/ru/yoomoney/gradle/plugins/gradleproject/ExtensionConfigurator.java
@@ -63,6 +63,11 @@ public class ExtensionConfigurator {
             nexusRepository.getUsername().set(System.getenv("NEXUS_USER"));
             nexusRepository.getPassword().set(System.getenv("NEXUS_PASSWORD"));
         });
+
+        //отключаем таску публикации, предоставляемую java-artifact-publish-plugin, т.к. io.github.gradle-nexus:publish-plugin
+        //предоставляет свою
+        project.afterEvaluate(p ->
+                project.getTasks().getByName("publishMainArtifactPublicationToMavenRepository").setEnabled(false));
     }
 
     private static void configurePublishPlugin(Project project) {


### PR DESCRIPTION
как устроена публикация в maven central:
артефакт публикуется в osstype. приэтом там создается временный репозиторий - staging repository.
Дальше есть два пути:
1) ручной. разработчик должен проверить, что публикуемый артефакт - ок, и закрыть staging репозиторий. После этого релиз выпускается в release repository и синкается с maven central.
2) автоматический. Для этого есть gradle-nexus/publish-plugin. он закрывает (и релизит) staging репозиторий.

При использовании плагина возникла проблема.
Новый плагин предоставляет таску для публикации. но у нас есть своя таска: publishMainArtifactPublicationToMavenRepository.
В итоге две таски живут вместе и выполняются одновременно.

Какие варианты рассматривала:
1) заставить внешний плагин не предоставлять таску - невозможно, плагин так не умеет
2) использовать только внешний плагин - невозможно, pom файл он не настраивает, подписи настраивать не умеет.
3) не предоставлять таску в нашем плагине - странно, плагин сейчас предоставляет полноценную публикацию
4) запускать при релизе одну конкретную таску - невозможно, во внешнем плагине есть завязка - перед вызовом таски close запускаются все publish таски.

Целевым решением вижу добавление поддержку работы с staging репозиториями в наш java-publish-plugin и не использовать внешний плагин совсем.
Но это не быстро - а релизы хочется пофиксить сейчас.

Как временный костыль предлагаю такой мьют таски. Кажется должно сработать (релиз с закрытием репозиториев сложно протестировать)

@f0y @Xsires @ul8422 может, есть идеи, как сделать лучше?
