### PR TITLE
Добавлена таска checkCoverage для поддержки общего скрипта сборки

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### NEXT_VERSION_TYPE=MAJOR|MINOR|PATCH
+### NEXT_VERSION_TYPE=PATCH
 ### NEXT_VERSION_DESCRIPTION_BEGIN
+* Добавлена таска checkCoverage для поддержки общего скрипта сборки
 ### NEXT_VERSION_DESCRIPTION_END
 ## [7.3.2](https://github.com/yoomoney-gradle-plugins/gradle-project-plugin/pull/6) (22-04-2021)
 

--- a/configurator.gradle
+++ b/configurator.gradle
@@ -119,6 +119,12 @@ jacocoTestReport {
 }
 check.dependsOn jacocoTestReport
 
+// создаем таску checkCoverage. В этом плагине она ничего не проверяет, но нужна для поддержки общего скрипта сборки
+// для yoomoney-gradle-plugins. см. yoomoney-gradle-plugins/travis-shared-configuration:build-and-publish-plugin.yml
+task checkCoverage {
+    dependsOn jacocoTestReport
+}
+
 group = 'ru.yoomoney.gradle.plugins'
 
 gradlePlugin {


### PR DESCRIPTION
чтобы проходила общая сборка и не создавала рекурсивная зависимость на java-plugin (во внутреннем плагине также сделано) 